### PR TITLE
Corrected const names in example/draw.go

### DIFF
--- a/example/draw.go
+++ b/example/draw.go
@@ -25,8 +25,8 @@ cairo_surface_t *surface =
 */
 
 func main() {
-	surface := cairo.NewSurface(cairo.FormatArgB32, 240, 80)
-	surface.SelectFontFace("serif", cairo.FontSlantNormal, cairo.FontWeightBold)
+	surface := cairo.NewSurface(cairo.FORMAT_ARGB32, 240, 80)
+	surface.SelectFontFace("serif", cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_BOLD)
 	surface.SetFontSize(32.0)
 	surface.SetSourceRGB(0.0, 0.0, 1.0)
 	surface.MoveTo(10.0, 50.0)


### PR DESCRIPTION
The example code refers to three constants that are defined in cairo.go using all-caps and underscores rather than camelcase. The code as it stood did not compile. The code now complies ok.
