### PR TITLE
Fix example

### DIFF
--- a/example/draw.go
+++ b/example/draw.go
@@ -25,12 +25,12 @@ cairo_surface_t *surface =
 */
 
 func main() {
-	surface := cairo.NewSurface(cairo.FormatArgB32, 240, 80)
-	surface.SelectFontFace("serif", cairo.FontSlantNormal, cairo.FontWeightBold)
+	surface := cairo.NewSurface(cairo.FORMAT_ARGB32, 240, 80)
+	surface.SelectFontFace("serif", cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_BOLD)
 	surface.SetFontSize(32.0)
 	surface.SetSourceRGB(0.0, 0.0, 1.0)
 	surface.MoveTo(10.0, 50.0)
 	surface.ShowText("Hello World")
-	surface.Finish()
 	surface.WriteToPNG("hello.png")
+	surface.Finish()
 }


### PR DESCRIPTION
The example/draw.go has two problems. The first, as outlined in another pull request, is the use of incorrect constants. The second problem is that it attempts to finish a surface before writing it out to a PNG. This is an invalid sequence of operations.

This patch fixes both of those issues.
