### PR TITLE
Remove -std=c11 flag from png.go

### DIFF
--- a/png.go
+++ b/png.go
@@ -1,6 +1,6 @@
 package cairo
 
-// #cgo CFLAGS: -std=c11 -Wall -O2
+// #cgo CFLAGS: -Wall -O2
 // #cgo pkg-config: cairo
 // #include <stdio.h>
 // #include <stdlib.h>


### PR DESCRIPTION
Remove `c11` flag to support older versions of GCC.