### PR TITLE
Support for cairo_image_surface_create_from_data

### DIFF
--- a/surface.go
+++ b/surface.go
@@ -37,6 +37,12 @@ func NewSurfaceFromC(s Cairo_surface, c Cairo_context) *Surface {
 	return &Surface{surface: s, context: c}
 }
 
+func NewSurfaceFromData(data unsafe.Pointer, format Format, width, height, stride int) *Surface {
+	s := C.cairo_image_surface_create_for_data((*C.uchar)(data), C.cairo_format_t(format),
+			C.int(width), C.int(height), C.int(stride))
+	return &Surface{surface: s, context: C.cairo_create(s)}
+}
+
 func NewSurfaceFromPNG(filename string) (*Surface, Status) {
 
 	cstr := C.CString(filename)


### PR DESCRIPTION
Pass in an unsafe.Pointer to the surface data. This allows for surfaces
to be created e.g. from an SDL surface (would address #3):

	package main

	import (
		"time"
		"github.com/veandco/go-sdl2/sdl"
		"github.com/ungerik/go-cairo"
	)

	func main() {
		sdl.Init(sdl.INIT_EVERYTHING);
		defer sdl.Quit()

		window, _ := sdl.CreateWindow("test", sdl.WINDOWPOS_UNDEFINED, sdl.WINDOWPOS_UNDEFINED,
			800, 600, sdl.WINDOW_SHOWN)
		sdlSurface, _ := window.GetSurface()
		sdlSurface.FillRect(nil, 0)

		cairoSurface := cairo.NewSurfaceFromData(sdlSurface.Data(),
			cairo.FORMAT_ARGB32, int(sdlSurface.W), int(sdlSurface.H),
			int(sdlSurface.Pitch))
		cairoSurface.SelectFontFace("serif", cairo.FONT_SLANT_NORMAL, cairo.FONT_WEIGHT_BOLD)
		cairoSurface.SetFontSize(32.0)
		cairoSurface.SetSourceRGB(0.0, 0.0, 1.0)
		cairoSurface.MoveTo(10.0, 50.0)
		cairoSurface.ShowText("Hello World")
		cairoSurface.Finish()

		window.UpdateSurface()

		time.Sleep(5 * time.Second)
	}