### PR TITLE
Adding SVGSurfaceSetDocumentUnit function

### DIFF
--- a/cairo.go
+++ b/cairo.go
@@ -114,6 +114,22 @@ const (
 	ANTIALIAS_SUBPIXEL
 )
 
+// cairo_svg_unit_t
+type SVGUnit int
+
+const (
+	CAIRO_SVG_UNIT_USER = iota
+	CAIRO_SVG_UNIT_EM
+	CAIRO_SVG_UNIT_EX
+	CAIRO_SVG_UNIT_PX
+	CAIRO_SVG_UNIT_IN
+	CAIRO_SVG_UNIT_CM
+	CAIRO_SVG_UNIT_MM
+	CAIRO_SVG_UNIT_PT
+	CAIRO_SVG_UNIT_PC
+	CAIRO_SVG_UNIT_PERCENT
+)
+
 // cairo_fill_rule_t
 type FillRule int
 

--- a/surface.go
+++ b/surface.go
@@ -130,6 +130,10 @@ func NewRecordingSurface(content Content, extents *Rectangle) *Surface {
 	return &Surface{surface: s, context: C.cairo_create(s)}
 }
 
+func (self *Surface) SVGSurfaceSetDocumentUnit(unit SVGUnit) {
+	C.cairo_svg_surface_set_document_unit(self.surface, C.cairo_svg_unit_t(unit))
+}
+
 func (self *Surface) GetCurrentPoint() (float64, float64) {
 	if !self.HasCurrentPoint() {
 		return 0, 0


### PR DESCRIPTION
Hi,
I discovered your repository recently and have been really enjoying using it to build a project for generating some art. But I realised it lacked the ability to set the unit for SVG's to PX, it defaults to PT unless the `cairo_svg_surface_set_document_unit` function is called. I have added a function to implement this, which can hopefully be merged, if I have done it correctly?
Thanks,
Jakob Glock