### PR TITLE
Adding NewEPSSurface function

### DIFF
--- a/cairo.go
+++ b/cairo.go
@@ -3,6 +3,7 @@
 package cairo
 
 // #cgo pkg-config: cairo
+// #include <cairo/cairo-ft.h>
 // #include <cairo/cairo-pdf.h>
 // #include <cairo/cairo-ps.h>
 // #include <cairo/cairo-svg.h>
@@ -401,7 +402,8 @@ type FontExtents struct {
 }
 
 type FontFace struct {
-	// todo
+	face    *C.cairo_font_face_t
+	ft_face *C.FT_Face
 }
 
 type FontOptions struct {

--- a/freetype.go
+++ b/freetype.go
@@ -1,0 +1,87 @@
+//go:build !goci
+// +build !goci
+
+package cairo
+
+/*
+#include <cairo/cairo.h>
+#include <cairo/cairo-ft.h>
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type Cairo_freetype struct {
+	library C.FT_Library
+}
+
+// Initialize a new FreeType library object
+func InitFreeType() (Cairo_freetype, error) {
+	var library C.FT_Library
+	err := C.FT_Init_FreeType(&library)
+	if err == 0 {
+		return Cairo_freetype{library: library}, nil
+	}
+	return Cairo_freetype{}, fmt.Errorf("FT_Init_FreeType error %v", err)
+}
+
+// Destroy a given FreeType library object and all of its children, including resources, drivers, faces, sizes, etc.
+func (ft Cairo_freetype) DoneFreeType() error {
+	if ft.library != nil {
+		err := C.FT_Done_FreeType(ft.library)
+		ft.library = nil
+		if err != 0 {
+			return fmt.Errorf("FT_Done_FreeType error %v", err)
+		}
+	}
+	return nil
+}
+
+// Call FT_Open_Face to open a font by its pathname
+func (ft Cairo_freetype) FtNewFace(filename string) (*FontFace, error) {
+	var face C.FT_Face
+	cs := C.CString(filename)
+	err := C.FT_New_Face(ft.library, cs, 0, &face)
+	C.free(unsafe.Pointer(cs))
+	if err != 0 {
+		return nil, fmt.Errorf("FT_New_Face error %v", err)
+	}
+
+	return &FontFace{
+		face:    C.cairo_ft_font_face_create_for_ft_face(face, 0),
+		ft_face: &face,
+	}, nil
+}
+
+// Call FT_Open_Face to open a font that has been loaded into memory
+func (ft Cairo_freetype) FtNewMemoryFace(data []byte) (*FontFace, error) {
+	var face C.FT_Face
+	err := C.FT_New_Memory_Face(ft.library, (*C.uchar)(&data[0]), C.long(len(data)), 0, &face)
+	if err != 0 {
+		return nil, fmt.Errorf("FT_New_Memory_Face error %v", err)
+	}
+
+	return &FontFace{
+		face:    C.cairo_ft_font_face_create_for_ft_face(face, 0),
+		ft_face: &face,
+	}, nil
+}
+
+// Discard a given face object, as well as all of its child slots and sizes
+func (ff *FontFace) FtDoneFace() error {
+	if ff.face != nil {
+		C.cairo_font_face_destroy(ff.face)
+		ff.face = nil
+	}
+	if ff.ft_face != nil {
+		err := C.FT_Done_Face(*ff.ft_face)
+		ff.ft_face = nil
+		if err != 0 {
+			return fmt.Errorf("FT_Done_Face error %v", err)
+		}
+	}
+	return nil
+}

--- a/surface.go
+++ b/surface.go
@@ -108,6 +108,15 @@ func NewPSSurface(filename string, widthInPoints, heightInPoints float64, level 
 	return &Surface{surface: s, context: C.cairo_create(s)}
 }
 
+func NewEPSSurface(filename string, widthInPoints, heightInPoints float64, level PSLevel) *Surface {
+	cs := C.CString(filename)
+	defer C.free(unsafe.Pointer(cs))
+	s := C.cairo_ps_surface_create(cs, C.double(widthInPoints), C.double(heightInPoints))
+	C.cairo_ps_surface_restrict_to_level(s, C.cairo_ps_level_t(level))
+	C.cairo_ps_surface_set_eps(s, 1)
+	return &Surface{surface: s, context: C.cairo_create(s)}
+}
+
 func NewSVGSurface(filename string, widthInPoints, heightInPoints float64, version SVGVersion) *Surface {
 	cs := C.CString(filename)
 	defer C.free(unsafe.Pointer(cs))

--- a/surface.go
+++ b/surface.go
@@ -485,7 +485,7 @@ func (self *Surface) GetFontOptions() *FontOptions {
 }
 
 func (self *Surface) SetFontFace(fontFace *FontFace) {
-	panic("not implemented") // todo
+	C.cairo_set_font_face(self.context, fontFace.face)
 }
 
 func (self *Surface) GetFontFace() *FontFace {


### PR DESCRIPTION
This is like NewPSSurface, but with an added call to C.cairo_ps_surface_set_eps

EPS is optimized for importing PS as an image into another document.